### PR TITLE
Set the status correctly if suspendDate or deleteDate are in the past

### DIFF
--- a/Pod/Classes/common/http/ProductionHttpClient.swift
+++ b/Pod/Classes/common/http/ProductionHttpClient.swift
@@ -28,15 +28,14 @@ open class ProductionHttpClient {
         params["access_token"] = accessToken
         if let lc = locale { params["locale"] = lc }
         let res = Just.get(nitrapiUrl + url, params: params)
-        
-       return try parseResult(res)
+        return try parseResult(res)
     }
     
     /// send a POST request
     open func dataPost(_ url: String,parameters: Dictionary<String, String>) throws -> NSDictionary? {
         let res = Just.post(nitrapiUrl + url, params: ["access_token": accessToken, "locale": locale ?? "en"], data: parameters)
 
-       return try parseResult(res)
+        return try parseResult(res)
     }
     
     /// send a PUT request
@@ -56,14 +55,14 @@ open class ProductionHttpClient {
     
     func parseResult(_ res: HTTPResult) throws -> NSDictionary? {
         // get rate limit
-        if (res.headers["X-RateLimit-Limit"] != nil) {
+        if res.headers["X-RateLimit-Limit"] != nil {
             rateLimit = Int(res.headers["X-RateLimit-Limit"]!)!
             rateLimitRemaining = Int(res.headers["X-RateLimit-Remaining"]!)!
             rateLimitReset = Int(res.headers["X-RateLimit-Reset"]!)!
         }
         
         var errorId: String? = nil
-        if (res.headers["X-Raven-Event-ID"] != nil) {
+        if res.headers["X-Raven-Event-ID"] != nil {
             errorId = res.headers["X-Raven-Event-ID"]
         }
         

--- a/Pod/Classes/services/Service.swift
+++ b/Pod/Classes/services/Service.swift
@@ -142,7 +142,7 @@ open class Service: Mappable {
         let now = Date()
         if deleteDate?.compare(now) == ComparisonResult.orderedAscending && status != .DELETED {
             status = .DELETING
-        } else if suspendDate?.compare(now) == ComparisonResult.orderedAscending && status != .SUSPENDED {
+        } else if suspendDate?.compare(now) == ComparisonResult.orderedAscending && status != .SUSPENDED && status != .DELETED {
             status = .SUSPENDING
         }
     }

--- a/Pod/Classes/services/Service.swift
+++ b/Pod/Classes/services/Service.swift
@@ -27,6 +27,12 @@ open class Service: Mappable {
         case ADMINLOCKED_SUSPENDED = "adminlocked_suspended"
         /// The service is deleted
         case DELETED = "deleted"
+        
+        // These statuses are set by fixServiceStatus() if suspendDate or deleteDate are in the past.
+        /// The service is currently being suspended.
+        case SUSPENDING
+        /// The service is currently being deleted.
+        case DELETING
     }
     
     // MARK: - Attributes
@@ -123,9 +129,21 @@ open class Service: Mappable {
     
     func postInit(_ nitrapi: Nitrapi) throws {
         self.nitrapi = nitrapi
+        
+        fixServiceStatus()
     }
     
     open func setAutoExtension(_ autoExtension: Bool) {
         self.autoExtension = autoExtension
+    }
+    
+    /// Sets the status correctly if suspendDate or deleteDate are in the past.
+    func fixServiceStatus() {
+        let now = Date()
+        if deleteDate?.compare(now) == ComparisonResult.orderedAscending && status != .DELETED {
+            status = .DELETING
+        } else if suspendDate?.compare(now) == ComparisonResult.orderedAscending && status != .SUSPENDED {
+            status = .SUSPENDING
+        }
     }
 }


### PR DESCRIPTION
When the user asks the NitrAPI to suspend a service, the suspendDate is set to the current time immediately. The status of the service is updated once the suspend action is finished. In this time the user can not yet delete the service.
To display this intermediate state, this adds new statuses for suspending and deleting.
They are set if suspendDate or deleteDate are in the past.